### PR TITLE
Add testcases

### DIFF
--- a/lib/fluent/plugin/filter_email_obfuscate.rb
+++ b/lib/fluent/plugin/filter_email_obfuscate.rb
@@ -20,7 +20,7 @@ module Fluent
     class EmailObfuscateFilter < Fluent::Plugin::Filter
       Fluent::Plugin.register_filter("email_obfuscate", self)
 
-      config_param :mode, :string, default: 'partial_name',
+      config_param :mode, :enum, list: [:partial_name, :full, :domain_only],  default: :partial_name,
         desc: <<-DESC
 'full' will replace all characters.
 'partial_name' will replace all characters in the 'domain' half of the address, and a subset of the 'name'.
@@ -38,11 +38,6 @@ DESC
 
       def configure(conf)
         super
-
-        if conf.has_key?('mode')
-          raise ConfigError, "'mode' must be one of: domain_only, full, partial_name" unless
-            ['domain_only', 'full', 'partial_name'].include?(conf.dig('mode'))
-        end
       end
 
       def hide_partial(str)
@@ -60,9 +55,9 @@ DESC
       def obfuscate(str)
         strmatch = str.match(/^([^@]+)(@.+)$/) { |m|
            case @mode
-           when 'domain_only'
+           when :domain_only
              m[1] + m[2].tr("@.a-zA-Z0-9", "@.*")
-           when 'full'
+           when :full
              m[1].gsub(/./, '*') + m[2].tr("@.a-zA-Z0-9", "@.*")
            else
              hide_partial(m[1]) + m[2].tr("@.a-zA-Z0-9", "@.*")

--- a/test/plugin/test_filter_email_obfuscate.rb
+++ b/test/plugin/test_filter_email_obfuscate.rb
@@ -6,13 +6,128 @@ class EmailObfuscateFilterTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
-  test "failure" do
-    flunk
+  CONF = %[
+  ]
+
+  def test_configure
+    d = create_driver
+    assert_equal :partial_name, d.instance.mode
+    assert_equal [], d.instance.suffix_whitelist
+  end
+
+  test "invalid mode" do
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONF + %[mode invalid])
+    end
+  end
+
+  test "filter" do
+    d = create_driver
+    sample_records = {
+      "f1": "myEmail@example.net",
+      "list1": [
+        "user1@example.com",
+        "user2@example.org"
+      ],
+      "a": {
+        "nested": {
+          "field": "name3@example.museum"
+        }
+      },
+      "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
+    }
+    d.run(default_tag: 'test') do
+      d.feed(sample_records)
+    end
+    expected = [{f1: "myEma**@*******.***",
+                 list1: ["user*@*******.***", "user*@*******.***"],
+                 a: {nested:
+                       {field: "name*@*******.******"}},
+                 email_string: "jane@*******.****, john@*******.****"}]
+    assert_equal expected, d.filtered.map{|e| e.last}
+  end
+
+  test "filter_full" do
+    d = create_driver(CONF + %[mode full])
+    sample_records = {
+      "f1": "myEmail@example.net",
+      "list1": [
+        "user1@example.com",
+        "user2@example.org"
+      ],
+      "a": {
+        "nested": {
+          "field": "name3@example.museum"
+        }
+      },
+      "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
+    }
+    d.run(default_tag: 'test') do
+      d.feed(sample_records)
+    end
+    expected = [{f1: "*******@*******.***",
+                 list1: ["*****@*******.***", "*****@*******.***"],
+                 a: {nested:
+                       {field: "*****@*******.******"}},
+                 email_string: "****@*******.****, ****@*******.****"}]
+    assert_equal expected, d.filtered.map{|e| e.last}
+  end
+
+  test "filter_domain_only" do
+    d = create_driver(CONF + %[mode domain_only])
+    sample_records = {
+      "f1": "myEmail@example.net",
+      "list1": [
+        "user1@example.com",
+        "user2@example.org"
+      ],
+      "a": {
+        "nested": {
+          "field": "name3@example.museum"
+        }
+      },
+      "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
+    }
+    d.run(default_tag: 'test') do
+      d.feed(sample_records)
+    end
+    expected = [{f1: "myEmail@*******.***",
+                 list1: ["user1@*******.***", "user2@*******.***"],
+                 a: {nested:
+                       {field: "name3@*******.******"}},
+                 email_string: "jane@*******.****, john@*******.****"}]
+    assert_equal expected, d.filtered.map{|e| e.last}
+  end
+
+  test "suffix whitelist" do
+    d = create_driver(CONF + %[suffix_whitelist [".example.com", "@example.com"]])
+    sample_records = {
+      "f1": "myEmail@example.net",
+      "list1": [
+        "user1@example.com",
+        "user2@subdomain.example.com"
+      ],
+      "a": {
+        "nested": {
+          "field": "name3@example.museum"
+        }
+      },
+      "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
+    }
+    d.run(default_tag: 'test') do
+      d.feed(sample_records)
+    end
+    expected = [{f1: "myEma**@*******.***",
+                 list1: ["user1@example.com", "user2@subdomain.example.com"],
+                 a: {nested:
+                       {field: "name*@*******.******"}},
+                 email_string: "jane@*******.****, john@*******.****"}]
+    assert_equal expected, d.filtered.map{|e| e.last}
   end
 
   private
 
-  def create_driver(conf)
+  def create_driver(conf = CONF)
     Fluent::Test::Driver::Filter.new(Fluent::Plugin::EmailObfuscateFilter).configure(conf)
   end
 end

--- a/test/plugin/test_filter_email_obfuscate.rb
+++ b/test/plugin/test_filter_email_obfuscate.rb
@@ -15,15 +15,8 @@ class EmailObfuscateFilterTest < Test::Unit::TestCase
     assert_equal [], d.instance.suffix_whitelist
   end
 
-  test "invalid mode" do
-    assert_raise(Fluent::ConfigError) do
-      create_driver(CONF + %[mode invalid])
-    end
-  end
-
-  test "filter" do
-    d = create_driver
-    sample_records = {
+  def sample_records
+    {
       "f1": "myEmail@example.net",
       "list1": [
         "user1@example.com",
@@ -36,6 +29,16 @@ class EmailObfuscateFilterTest < Test::Unit::TestCase
       },
       "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
     }
+  end
+
+  test "invalid mode" do
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONF + %[mode invalid])
+    end
+  end
+
+  test "filter" do
+    d = create_driver
     d.run(default_tag: 'test') do
       d.feed(sample_records)
     end
@@ -49,19 +52,6 @@ class EmailObfuscateFilterTest < Test::Unit::TestCase
 
   test "filter_full" do
     d = create_driver(CONF + %[mode full])
-    sample_records = {
-      "f1": "myEmail@example.net",
-      "list1": [
-        "user1@example.com",
-        "user2@example.org"
-      ],
-      "a": {
-        "nested": {
-          "field": "name3@example.museum"
-        }
-      },
-      "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
-    }
     d.run(default_tag: 'test') do
       d.feed(sample_records)
     end
@@ -75,19 +65,6 @@ class EmailObfuscateFilterTest < Test::Unit::TestCase
 
   test "filter_domain_only" do
     d = create_driver(CONF + %[mode domain_only])
-    sample_records = {
-      "f1": "myEmail@example.net",
-      "list1": [
-        "user1@example.com",
-        "user2@example.org"
-      ],
-      "a": {
-        "nested": {
-          "field": "name3@example.museum"
-        }
-      },
-      "email_string": "Jane Doe <jane@example.name>, John Smith <john@example.name>"
-    }
     d.run(default_tag: 'test') do
       d.feed(sample_records)
     end


### PR DESCRIPTION
Hi, I tried to write test cases for `#configure`, filter modes, and suffix whitelist.
And I also use `:enum` type for mode config parameter.
Because :enum built-in type can handle invalid value as `Fluent::ConfigError`.